### PR TITLE
Add project README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,46 @@
+# CLAUDE.md
+
+## Project Overview
+
+Personal website for Tomek Drwięga at [todr.me](https://todr.me). Built with Astro v5, deployed as a static site.
+
+## Key Conventions
+
+- **README sync:** All changes to website content (projects, blog posts, pages) must be reflected in `README.md`. Keep it up to date.
+- Site URL: `https://todr.me`
+- Homepage redirects to `/projects`
+
+## Project Structure
+
+```
+src/
+  content/blog/     # Markdown blog posts (frontmatter: title, date, author, categories, tags, image)
+  data/projects.ts  # Projects list shown on /projects page (grouped by category)
+  data/settings.ts  # Site-wide settings (title, menu, social links)
+  pages/            # Astro page routes
+  layouts/          # Page layouts
+  components/       # Reusable components
+  styles/           # Sass stylesheets
+public/             # Static assets
+```
+
+## Commands
+
+```bash
+npm run dev       # Start dev server (localhost:4321)
+npm run build     # Production build
+npm run preview   # Preview production build
+```
+
+## Content Editing
+
+### Adding a blog post
+1. Create `src/content/blog/YYYY-MM-DD-slug.md` with frontmatter (title, date, author, categories, tags, image)
+2. Add an entry to the Blog Posts table in `README.md`
+
+### Adding a project
+1. Add an entry to the appropriate category in `src/data/projects.ts`
+2. Add a row to the matching Projects table in `README.md`
+
+### Changing site settings
+Edit `src/data/settings.ts` for menu items, social links, and site metadata.

--- a/README.md
+++ b/README.md
@@ -1,267 +1,65 @@
-# Millennial
+# todr.me
 
-Millennial is a minimalist Jekyll theme for running a simple, clean, content-focused publishing platform for your publication site or blog through [Github Pages](https://pages.github.com/), or on your own server. Everything that you will ever need to know about this Jekyll theme is included in the README below, which you can also find in [the demo site](https://lenpaul.github.io/Millennial/).
+Personal website of Tomek Drwięga, built with [Astro](https://astro.build/) and deployed at [todr.me](https://todr.me).
 
-![alt text](https://user-images.githubusercontent.com/8409329/32801138-33a72030-c94a-11e7-8a62-6184e6df5a8f.png "Millennial Demo Image")
+> **Important:** All changes to the website content should be reflected in this README. Keep this file in sync with the site.
 
-## Notable features
+## Pages
 
-* Compatible with GitHub Pages.
+| Page | Path | Description |
+|------|------|-------------|
+| Home | `/` | Redirects to `/projects` |
+| Projects | `/projects` | Showcase of open-source projects |
+| Blog | `/blog` | Blog posts |
+| Contact | `/contact` | Contact information |
 
-* Support for Jekyll's built-in Sass/SCSS preprocessor and data files for making customizing easier.
+## Projects
 
-* [Google Analytics](https://www.google.com/analytics/) support.
+### Blockchain & Web3
 
-* Commenting support powered by [Disqus](https://disqus.com/).
+| Project | Description |
+|---------|-------------|
+| [pvm-decompiler](https://tomusdrw.github.io/pvm-decompiler) ([repo](https://github.com/tomusdrw/pvm-decompiler)) | Decompiler for PVM (Polkadot Virtual Machine) bytecode that emits structured, readable pseudo-code |
+| [anan-as](https://tomusdrw.github.io/anan-as) ([repo](https://github.com/tomusdrw/anan-as)) | AssemblyScript implementation of the JAM PVM (64-bit). Powers the PVM backend of the typeberry JAM client |
+| [as-lan](https://tomusdrw.github.io/as-lan) ([repo](https://github.com/tomusdrw/as-lan)) | AssemblyScript SDK for building JAM services |
+| [wasm-pvm](https://tomusdrw.github.io/wasm-pvm) ([repo](https://github.com/tomusdrw/wasm-pvm)) | Rust compiler translating WebAssembly bytecode into PolkaVM (PVM) bytecode via LLVM IR |
+| [eth-opcodevis](https://tomusdrw.github.io/eth-opcodevis) ([repo](https://github.com/tomusdrw/eth-opcodevis)) | Interactive visualiser for Ethereum smart contract bytecode |
+| [rust-web3](https://tomusdrw.github.io/rust-web3) ([repo](https://github.com/tomusdrw/rust-web3)) | Rust implementation of Web3.js — an Ethereum JSON-RPC multi-transport client |
 
-* Optimized for search engines.
+### Visualizations & Tools
 
-* LaTeX support through [MathJax](https://www.mathjax.org/).
+| Project | Description |
+|---------|-------------|
+| [trumpet](https://tomusdrw.github.io/trumpet) ([repo](https://github.com/tomusdrw/trumpet)) | Browser-based trumpet tuner with real-time pitch detection and fingering chart |
+| [blacksoft.graph.vis](https://tomusdrw.github.io/blacksoft.graph.vis) ([repo](https://github.com/tomusdrw/blacksoft.graph.vis)) | Animated visualisation of graph algorithms using arbor.js |
+| [kdtree](https://tomusdrw.github.io/kdtree) ([repo](https://github.com/tomusdrw/kdtree)) | JavaScript k-d tree implementation with interactive demos |
+| [rust-type-visualiser](https://tomusdrw.github.io/rust-type-visualiser) ([repo](https://github.com/tomusdrw/rust-type-visualiser)) | Visualise deeply nested Rust generic types from compiler errors |
+| [rust-assert-diff](https://tomusdrw.github.io/rust-assert-diff) ([repo](https://github.com/tomusdrw/rust-assert-diff)) | Highlighted diff viewer for Rust test assertion failures |
+| [corewords](https://fluffyassist.github.io/corewords) ([repo](https://github.com/FluffyAssist/corewords)) | Polish AAC core words app — 500 key words for alternative communication |
 
-## Table of Contents
+## Blog Posts
 
-1. [Introduction](#introduction)
-   1. [What is Jekyll](#what-is-jekyll)
-   2. [Never Used Jeykll Before?](#never-used-jekyll-before)
-2. [Installation](#installation)
-   1. [GitHub Pages Installation](#github-pages-installation)
-   2. [Local Installation](#local-installation)
-   3. [Directory Structure](#directory-structure)
-   4. [Starting From Scratch](#starting-from-scratch)
-3. [Configuration](#configuration)
-   1. [Sample Posts](#sample-posts)
-   2. [Site Variables](#site-variables)
-   3. [Adding Menu Pages](#adding-menu-pages)
-   4. [Posts](#posts)
-   5. [Layouts](#layouts)
-   6. [YAML Front Block Matter](#yaml-front-block-matter)
-4. [Features](#features)
-   1. [Design Considerations](#design-considerations)
-   2. [Disqus](#disqus)
-   3. [Google Analytics](#google-analytics)
-   4. [RSS Feeds](#rss-feeds)
-   5. [Social Media Icons](#social-media-icons)
-   6. [MathJax](#mathjax)
-   7. [Syntax Highlighting](#syntax-highlighting)
-   8. [Markdown](#markdown)
-5. [Everything Else](#everything-else)
-6. [Contributing](#Contributing)
-7. [Questions?](#questions)
-8. [Credits](#credits)
-9. [License](#license)
+| Date | Title | Link |
+|------|-------|------|
+| 2025-01-20 | Building the Future with FluffyLabs and Typeberry | [todr.me/building-the-future-with-fluffylabs-and-typeberry](https://todr.me/building-the-future-with-fluffylabs-and-typeberry) |
+| 2015-01-12 | Jak przeszliśmy od Java do Javascript | [todr.me/jak-przeszlismy-od-java-do-javascript](https://todr.me/jak-przeszlismy-od-java-do-javascript) |
 
-## Introduction
-
-Millennial is a Jekyll theme that was built to be 100% compatible with [GitHub Pages](https://pages.github.com/). If you are unfamiliar with GitHub Pages, you can check out [their documentation](https://help.github.com/categories/github-pages-basics/) for more information. [Jonathan McGlone's guide](http://jmcglone.com/guides/github-pages/) on creating and hosting a personal site on GitHub is also a good resource.
-
-### What is Jekyll?
-
-Jekyll is a simple, blog-aware, static site generator for personal, project, or organization sites. Basically, Jekyll takes your page content along with template files and produces a complete website. For more information, visit the [official Jekyll site](https://jekyllrb.com/docs/home/) for their documentation. Codecademy also offers a great course on [how to deploy a Jekyll site](https://www.codecademy.com/learn/deploy-a-website) for complete beginners.
-
-### Never Used Jekyll Before?
-
-The beauty of hosting your website on GitHub is that you don't have to actually have Jekyll installed on your computer. Everything can be done through the GitHub code editor, with minimal knowledge of how to use Jekyll or the command line. All you have to do is add your posts to the `_posts` directory and edit the `_config.yml` file to change the site settings. With some rudimentary knowledge of HTML and CSS, you can even modify the site to your liking. This can all be done through the GitHub code editor, which acts like a content management system (CMS).
-
-## Installation
-
-### GitHub Pages Installation
-
-To start using Jekyll right away with GitHub Pages, [fork the Millennial repository on GitHub](https://github.com/LeNPaul/Millennial/fork). From there, you can rename your repository to `USERNAME.github.io`, where `USERNAME` is your GitHub username, and edit the `settings.yml` file in the `_data` folder to your liking. Ensure that you have a branch named `gh-pages`. Your website should be ready immediately at 'http://USERNAME.github.io'. Note: if you are hosting several sites under the same GitHub username, then you will have to use [Project Pages instead of User Pages](https://help.github.com/articles/user-organization-and-project-pages/) - just change the repository name to something other than 'http://USERNAME.github.io'.
-
-Head over to the `_posts` directory to view all the posts that are currently on the website, and to see examples of what post files generally look like. You can simply just duplicate the template post and start adding your own content.
-
-### Local Installation
-
-For a full local installation of Millennial, [download your own copy of Millennial](https://github.com/LeNPaul/Millennial/archive/gh-pages.zip) and unzip it into it's own directory. From there, open up your favorite command line tool, enter `bundle install`, and then enter `jekyll serve`. Your site should be up and running locally at [http://localhost:4000](http://localhost:4000).
-
-### Directory Structure
-
-If you are familiar with Jekyll, then the Millennial directory structure shouldn't be too difficult to navigate. The following some highlights of the differences you might notice between the default directory structure. More information on what these folders and files do can be found in the [Jekyll documentation site](https://jekyllrb.com/docs/structure/).
+## Development
 
 ```bash
-Millennial/
-├── _data                      # Data files
-|  └── settings.yml            # Theme settings and custom text
-├── _includes                  # Theme includes
-├── _layouts                   # Theme layouts (see below for details)
-├── _posts                     # Where all your posts will go
-├── assets                     # Style sheets and images are found here
-|  ├── css                     # Style sheets go here
-|  |  └── _sass                # Folder containing SCSS files
-|  |  └── main.scss            # Main SCSS file
-|  |  └── syntax.css           # Style sheet for code syntax highlighting
-|  └── img                     # Images go here
-├── pages                      # Category pages
-├── _config.yml                # Site build settings
-├── Gemfile                    # Ruby Gemfile for managing Jekyll plugins
-├── index.md                   # Home page
-├── LICENSE.md                 # License for this theme
-├── README.md                  # Includes all of the documentation for this theme
-└── rss-feed.xml               # Generates RSS 2.0 file which Jekyll points to
+npm install
+npm run dev       # Start dev server
+npm run build     # Production build
+npm run preview   # Preview production build
 ```
 
-### Starting From Scratch
-
-To completely start from scratch, simply delete all the files in the `_posts`, `assets/img`, and `pages` folder, and add your own content. You may also replace the `README.md` file with your own README. Everything in the `_data` folder and `_config.yml` file can be edited to suit your needs. You may also change the `favicon.ico` file to your own favicon.
-
-## Configuration
-
-### Sample Posts
-
-Visit the [the demo site](https://lenpaul.github.io/Millennial/) to find sample posts that show what different types of text formatting look like. You can find these posts in the `_posts` folder, which show what the best practices for setting up your own site are.
-
-### Site Variables
-
-To change site build settings, edit the `_config.yml` file found in the root of your repository, which you can tweak however you like. More information on configuration settings and plugins can be found on [the Jekyll documentation site](https://jekyllrb.com/docs/configuration/). This is also where you will be able to customize the title, description, and the author/owner of your site.
-
-If you are hosting your site on GitHub Pages, then committing a change to the `_config.yml` file will force a rebuild of your site with Jekyll. Any changes made should be viewable soon after. If you are hosting your site locally, then you must run `jekyll serve` again for the changes to take place.
-
-In the `settings.yml` file found in the `_data` folder, you will be able to customize your site settings, such as setting Disqus comments, Google Analytics, what shows up in your menu, and social media information.
-
-### Adding Menu Pages
-
-The menu pages are found in the `menu` folder in the root directory, and can be added to your menu in the `settings.yml` file.
-
-### Posts
-
-You will find example posts in your `_posts` directory. Go ahead and edit any post and re-build the site to see your changes. You can rebuild the site in many different ways, but the most common way is to run `jekyll serve`, which launches a web server and auto-regenerates your site when a file is updated.
-
-To add new posts, simply add a file in the `_posts` directory that follows the convention of `YYYY-MM-DD-name-of-post.md` and includes the necessary front matter. Take a look at any sample post to get an idea about how it works. If you already have a website built with Jekyll, simply copy over your posts to migrate to Millennial.
-
-### Layouts
-
-There are two main layout options that are included with Millennial: post and page. Layouts are specified through the [YAML front block matter](https://jekyllrb.com/docs/frontmatter/). Any file that contains a YAML front block matter will be processed by Jekyll. For example:
-
-```
----
-layout: post
-title: "Example Post"
----
-```
-
-Examples of what posts looks like can be found in the `_posts` directory, which includes this post you are reading right now. Posts are the basic blog post layout, which includes a header image, post content, author name, date published, social media sharing links, and related posts.
-
-Pages are essentially the post layout without any of the extra features of the posts layout. An example of what pages look like can be found at the [documentation page](https://lenpaul.github.io/Millennial/pages/documentation.html).
-
-In addition to the two main layout options above, there are also custom layouts that have been created for the [home page](https://lenpaul.github.io/Millennial/) and the [contacts page](https://lenpaul.github.io/Millennial/pages/contact.html). These are simply just page layouts with some [Liquid template code](https://shopify.github.io/liquid/). Check out the `index.html` file in the root directory for what the code looks like.
-
-### YAML Front Block Matter
-
-The recommended YAML front block is:
-
-```
----
-layout:
-title:
-author:
-categories:
-tags: []
-image:
----
-```
-
-`layout` specifies which layout to use, `title` is the page or post title, `categories` can be used to better organize your posts, `tags` are used when generating related posts based on the topic of the post, and `image` specifies which images to use. Have a look at some posts in the `_posts` directory to see how these variables are set.
-
-## Features
-
-### Design Considerations
-
-Millennial was designed to be a minimalist theme in order for the focus to remain on your content. For example, links are signified mainly through an underline text-decoration, in order to maximize the perceived affordance of clickability (I originally just wanted to make the links a darker shade of grey).
-
-### Disqus
-
-Millennial supports comments at the end of posts through [Disqus](https://disqus.com/). In order to activate Disqus commenting, set `disqus.comments` to true in the `_data/settings.yml` file. If you do not have a Disqus account already, you will have to set one up, and create a profile for your website. You will be given a `disqus_shortname` that will be used to generate the appropriate comments sections for your site. More information on [how to set up Disqus](http://www.perfectlyrandom.org/2014/06/29/adding-disqus-to-your-jekyll-powered-github-pages/).
-
-### Google Analytics
-
-It is possible to track your site statistics through [Google Analytics](https://www.google.com/analytics/). Similar to Disqus, you will have to create an account for Google Analytics, and enter the correct Google ID for your site under `google-ID` in the `settings.yml` file. More information on [how to set up Google Analytics](https://michaelsoolee.com/google-analytics-jekyll/). Note: If you are not using Google Analytics, please change `google-ID` to an empty string.
-
-### RSS Feeds
-
-Atom is supported by default through [jekyll-feed](https://github.com/jekyll/jekyll-feed). With jekyll-feed, you can set configuration variables such as 'title', 'description', and 'author', in the `_config.yml` file.
-
-RSS 2.0 is also supported through [RSS auto-discovery](http://www.rssboard.org/rss-autodiscovery). The `rss-feed.xml` file (based on the template found at [jekyll-rss-feeds](https://github.com/snaptortoise/jekyll-rss-feeds)) that the feed path points to when using RSS 2.0 is automatically generated based on the appropriate configuration variables found in `_data/settings.yml`.
-
-To use RSS 2.0, ensure the following is done:
-
-* Uncomment the last two lines in the `_config.yml` file.
-
-* In `_data/settings.yml`, under 'social', comment out the rss-square that points to `feed.xml`, and uncomment the rss-square that points to `rss-feed.xml`.
-
-* In `_includes/head.html`, comment out `{% feed_meta %}` and uncomment the line under the RSS 2.0 comment.
-
-### Social Media Icons
-
-All social media icons are courtesy of [Font Awesome](http://fontawesome.io/). You can change which icons appear, as well as the account that they link to, in the `settings.yml` file in the `_data` folder.
-
-### MathJax
-
-Millennial comes out of the box with [MathJax](https://www.mathjax.org/), which allows you to display mathematical equations in your posts through the use of [LaTeX](http://www.andy-roberts.net/writing/latex/mathematics_1).
-
-### Syntax Highlighting
-
-Millennial provides syntax highlighting through [fenced code blocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/). Syntax highlighting allows you to display source code in different colors and fonts depending on what programming language is being displayed. You can find the full list of supported programming languages [here](https://github.com/jneen/rouge/wiki/List-of-supported-languages-and-lexers). Another option is to embed your code through [Gist](https://en.support.wordpress.com/gist/).
-
-### Markdown
-
-As always, Jekyll offers support for GitHub Flavored Markdown, which allows you to format your posts using the [Markdown syntax](https://guides.github.com/features/mastering-markdown/). Examples of these text formatting features can be seen below. You can find this post in the `_posts` directory as well as the `README.md` file.
-
-## Everything Else
-
-Check out the [Jekyll docs][jekyll-docs] for more info on how to get the most out of Jekyll. File all bugs/feature requests at [Jekyll's GitHub repo][jekyll-gh]. If you have questions, you can ask them on [Jekyll Talk][jekyll-talk].
-
-[jekyll-docs]: http://jekyllrb.com/docs/home
-[jekyll-gh]:   https://github.com/jekyll/jekyll
-[jekyll-talk]: https://talk.jekyllrb.com/
-
-## Contributing
-
-If you would like to make a feature request, or report a bug or typo in the documentation, then please [submit a GitHub issue](https://github.com/LeNPaul/Millennial/issues/new). If you would like to make a contribution, then feel free to [submit a pull request](https://help.github.com/articles/about-pull-requests/) - as a bonus, I will credit all contributors below! If this is your first pull request, it may be helpful to read up on the [GitHub Flow](https://guides.github.com/introduction/flow/) first.
-
-Millennial has been designed as a base for users to customize and fit to their own unique needs. Please keep this in mind when requesting features and/or submitting pull requests. Some examples of changes that I would love to see are things that would make the site easier to use, or better ways of doing things. Please avoid changes that do not benefit the majority of users.
-
-## Questions?
-
-This theme is completely free and open source software. You may use it however you want, as it is distributed under the [MIT License](http://choosealicense.com/licenses/mit/). If you are having any problems, any questions or suggestions, feel free to [tweet at me](https://twitter.com/intent/tweet?text=My%question%about%Millennial%is:%&amp;via=paululele), or [file a GitHub issue](https://github.com/lenpaul/Millennial/issues/new).
-
-## Credits
-
-### Creator
-
-#### Paul Le
-
-* [www.lenpaul.com](http://lenpaul.com)
-
-* [Twitter](https://twitter.com/paululele)
-
-* [GitHub](https://github.com/LeNPaul)
-
-### Contributors
-
-* [b-morawiec](https://github.com/b-morawiec)
-
-* [JainVikas](https://github.com/JainVikas)
-
-* [mschaeffner](https://github.com/mschaeffner)
-
-* [cfe316](https://github.com/cfe316)
-
-* [JeremyGonzales](https://github.com/JeremyGonzales)
-
-### Icons + Demo Images
-
-* [Death to Stock](https://deathtothestockphoto.com/)
-
-* [Font Awesome](http://fontawesome.io/)
-
-### Other
-
-* [Jekyll](https://jekyllrb.com/)
-
-* [Free Code Camp](https://www.freecodecamp.org)
-
-* [Khan Academy](https://www.khanacademy.org/)
+## Tech Stack
+
+- [Astro](https://astro.build/) v5 — static site generator
+- [Sass](https://sass-lang.com/) — styling
+- [@astrojs/sitemap](https://docs.astro.build/en/guides/integrations-guide/sitemap/) — sitemap generation
+- [@astrojs/rss](https://docs.astro.build/en/guides/rss/) — RSS feed
 
 ## License
 
-Open sourced under the [MIT license](https://github.com/LeNPaul/Millennial/blob/gh-pages/LICENSE.md).
+[MIT](LICENSE.md)


### PR DESCRIPTION
## Summary
- Replace outdated Jekyll Millennial theme README with project-specific documentation including all projects (with live/repo links), blog post links, pages overview, dev commands, and tech stack.
- Add CLAUDE.md documenting project structure, content editing workflows, and the convention that all website content changes must be reflected in README.md.

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm project links and blog post URLs resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)