### PR TITLE
Add latest repos to projects page

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,21 @@ Personal website of Tomek Drwięga, built with [Astro](https://astro.build/) and
 
 | Project | Description |
 |---------|-------------|
+| [relativity-simulations](https://tomusdrw.github.io/relativity-simulations) ([repo](https://github.com/tomusdrw/relativity-simulations)) | Interactive WebGL special relativity simulator with twin paradox and light-signal propagation |
 | [trumpet](https://tomusdrw.github.io/trumpet) ([repo](https://github.com/tomusdrw/trumpet)) | Browser-based trumpet tuner with real-time pitch detection and fingering chart |
 | [blacksoft.graph.vis](https://tomusdrw.github.io/blacksoft.graph.vis) ([repo](https://github.com/tomusdrw/blacksoft.graph.vis)) | Animated visualisation of graph algorithms using arbor.js |
 | [kdtree](https://tomusdrw.github.io/kdtree) ([repo](https://github.com/tomusdrw/kdtree)) | JavaScript k-d tree implementation with interactive demos |
 | [rust-type-visualiser](https://tomusdrw.github.io/rust-type-visualiser) ([repo](https://github.com/tomusdrw/rust-type-visualiser)) | Visualise deeply nested Rust generic types from compiler errors |
 | [rust-assert-diff](https://tomusdrw.github.io/rust-assert-diff) ([repo](https://github.com/tomusdrw/rust-assert-diff)) | Highlighted diff viewer for Rust test assertion failures |
 | [corewords](https://fluffyassist.github.io/corewords) ([repo](https://github.com/FluffyAssist/corewords)) | Polish AAC core words app — 500 key words for alternative communication |
+
+### Libraries & Automation
+
+| Project | Description |
+|---------|-------------|
+| [fjall-js](https://github.com/tomusdrw/fjall-js) | TypeScript/Node.js bindings for the fjall LSM-tree storage engine with pre-built native binaries |
+| [telemach-bot](https://github.com/tomusdrw/telemach-bot) | Telegram bot forwarding messages and transcribed voice notes to email with LLM-generated subjects |
+| [github-notifications](https://github.com/tomusdrw/github-notifications) | GitHub notification poller that hydrates content into a JSONL feed for LLM pipelines |
 
 ## Blog Posts
 

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -56,6 +56,14 @@ export const projects = [
     category: 'Visualizations & Tools',
     items: [
       {
+        name: 'relativity-simulations',
+        url: 'https://tomusdrw.github.io/relativity-simulations',
+        repo: 'https://github.com/tomusdrw/relativity-simulations',
+        description: 'Interactive WebGL visualization of special relativity demonstrating the twin paradox. Features four relativistic clocks, light-signal propagation, and click-to-place interaction with configurable speed and distance.',
+        created: '2026-07',
+        updated: '2026-07',
+      },
+      {
         name: 'trumpet',
         url: 'https://tomusdrw.github.io/trumpet',
         repo: 'https://github.com/tomusdrw/trumpet',
@@ -102,6 +110,35 @@ export const projects = [
         description: 'Polish AAC (Augmentative and Alternative Communication) core words app. A curated list of 500 key words for building alternative communication systems, ranked by communicative priority.',
         created: '2026-03',
         updated: '2026-03',
+      },
+    ],
+  },
+  {
+    category: 'Libraries & Automation',
+    items: [
+      {
+        name: 'fjall-js',
+        url: 'https://github.com/tomusdrw/fjall-js',
+        repo: 'https://github.com/tomusdrw/fjall-js',
+        description: 'TypeScript/Node.js bindings for the fjall LSM-tree storage engine. Ships pre-built native binaries for macOS and Linux, with safe cross-thread sharing via Node worker_threads.',
+        created: '2026-06',
+        updated: '2026-06',
+      },
+      {
+        name: 'telemach-bot',
+        url: 'https://github.com/tomusdrw/telemach-bot',
+        repo: 'https://github.com/tomusdrw/telemach-bot',
+        description: 'Personal Telegram bot that forwards messages, attachments, and transcribed voice notes to email. LLM-generated subject lines via OpenRouter, delivery via Resend. Multi-user with admin approval.',
+        created: '2026-05',
+        updated: '2026-06',
+      },
+      {
+        name: 'github-notifications',
+        url: 'https://github.com/tomusdrw/github-notifications',
+        repo: 'https://github.com/tomusdrw/github-notifications',
+        description: 'Polls GitHub notifications, hydrates content, and appends to a local JSONL feed file. A capture-only pipeline designed for LLM-powered notification processing.',
+        created: '2026-06',
+        updated: '2026-07',
       },
     ],
   },

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -5,8 +5,8 @@ import { projects } from '../data/projects';
 
 <BaseLayout title="Projects" layoutClass="page">
   <div class="projects-page">
-    <h1>// DEPLOYED PROJECTS</h1>
-    <p class="projects-subtitle">GitHub Pages deployments</p>
+    <h1>// OPEN SOURCE PROJECTS</h1>
+    <p class="projects-subtitle">Tools, libraries & experiments</p>
 
     {projects.map(category => (
       <div class="project-category">


### PR DESCRIPTION
## Summary

- Add 4 new repos to the projects page: **relativity-simulations**, **fjall-js**, **telemach-bot**, and **github-notifications**
- Create a new "Libraries & Automation" category for non-deployed projects (fjall-js, telemach-bot, github-notifications)
- Update page title from "DEPLOYED PROJECTS" to "OPEN SOURCE PROJECTS" to reflect the broader scope
- Update README.md to match

## Test plan

- [ ] Verify the projects page renders all new entries correctly
- [ ] Verify project cards link to the correct URLs (GitHub Pages for relativity-simulations, GitHub repos for the rest)
- [ ] Verify the SOURCE button links to the correct repo for each new project

🤖 Generated with [Claude Code](https://claude.com/claude-code)